### PR TITLE
Update docs for `--publish-url` to avoid duplicated sentence

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4614,8 +4614,6 @@ pub struct PublishArgs {
     /// and index upload.
     ///
     /// Defaults to PyPI's publish URL (<https://upload.pypi.org/legacy/>).
-    ///
-    /// The default value is publish URL for PyPI (<https://upload.pypi.org/legacy/>).
     #[arg(long, env = EnvVars::UV_PUBLISH_URL)]
     pub publish_url: Option<Url>,
 


### PR DESCRIPTION
## Summary

These two sentences in the docs for `--publish-url` seem to basically be duplicates:

https://github.com/astral-sh/uv/blob/3eda248ef5678fe07b5424fb4f256011800fbb15/crates/uv-cli/src/lib.rs#L4616-L4618

I found the first to be easier to read, so this commit removes the second.

## Test Plan

No tests, change is docs-only.
