### PR TITLE
Include new package name mistake suggestions

### DIFF
--- a/crates/uv/src/commands/suggestions.json
+++ b/crates/uv/src/commands/suggestions.json
@@ -1,4 +1,18 @@
 [
+  ["arcpy", "arcgis"],
+  ["absl", "absl-py"],
+  ["auth0", "auth0-python"],
+  ["bs4", "beautifulsoup4"],
+  ["cv2", "opencv-python"],
+  ["docx", "python-docx"],
+  ["dotenv", "python-dotenv"],
+  ["fitz", "pymupdf"],
+  ["git", "gitpython"],
+  ["msoffcrypto", "msoffcrypto-tool"],
+  ["pil", "pillow"],
+  ["skgstat", "scikit-gstat"],
+  ["skimage", "scikit-image"],
   ["sklearn", "scikit-learn"],
-  ["dotenv", "python-dotenv"]
+  ["xrspatial", "xarray-spatial"],
+  ["yaml", "pyyaml"],
 ]


### PR DESCRIPTION
## Summary

This list of known discrepancies between package vs. import package name is missing a few very popular packages:

- PIL
- GitPython
- PyYAML

I have added these and a number of others I am aware of. These projects are of varying popularity, so I would understand if you don't want to include all of these, lest it gets out of control. These are just some suggestions to start a conversation.

## Test Plan

No tests, since this is just adding to a JSON file. The list should be manually reviewed.
